### PR TITLE
debug-tools: include array

### DIFF
--- a/debug-tools/bootlogger/Logger.cpp
+++ b/debug-tools/bootlogger/Logger.cpp
@@ -26,6 +26,7 @@
 #include <system_error>
 #include <unistd.h>
 
+#include <array>
 #include <atomic>
 #include <cstring>
 #include <filesystem>


### PR DESCRIPTION
This fixes the following build error:
hardware/samsung-ext/interfaces/debug-tools/bootlogger/Logger.cpp:162:27: error: implicit instantiation of undefined template 'std::array<char, 512>'